### PR TITLE
Fix driver parameters

### DIFF
--- a/blink.py
+++ b/blink.py
@@ -63,7 +63,7 @@ def main(input_file, window_size, time_out):
 
     print("[:] Processing %s URL(s)" % (page_amount))
 
-    driver = webdriver.Chrome(options=options)
+    driver = webdriver.Chrome(chrome_options=options)
     driver.set_page_load_timeout(time_out)
 
     for url in url_list:


### PR DESCRIPTION
![screenshot 2018-10-28 at 00 10 05](https://user-images.githubusercontent.com/116841/47609833-d1f72100-da46-11e8-9c78-2a4080802626.png)

The chrome driver should receiver `chrome_options` as parameter not `options` that was what caused the error shown on the image above.

More info on:
https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.chrome.webdriver