### PR TITLE
Issue #2,  added feature to set input type to single/bulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ If you do not have `pipenv` installed, first install it with `pip3 install pipen
 Usage: blink.py [OPTIONS]
 
 Options:
-  -i, --input TEXT        name of the input file (must be text file format;
-                          urls line by line).  [required]
+  -it, --input_type TEXT  type of the input (can be single/bulk followed by the url/textFile).  [required]
   -o, --output TEXT       name of the folder to save the screenshots to.
                           [default: screenshots]
   -ws, --windowsize TEXT  window size of the screenshot.  [default: 1200x600]
@@ -26,13 +25,22 @@ Options:
 ### Example
 
 ```console
-python3 blink.py -i example -o example -ws 1920x1080 -to 5
+python3 blink.py -it single acme.com -o example -ws 1920x1080 -to 5
+
+[:] Creating example folder...
+[:] Processing 1 URL(s)
+[1/1] Opening acme.com
+[:] Done processing example.txt
+
+python3 blink.py -it bulk example.txt -o example -ws 1920x1080 -to 5
 
 [:] Creating example folder...
 [:] Processing 1 URL(s)
 [1/1] Opening acme.com
 [:] Done processing example.txt
 ```
+
+
 
 ### Format
 

--- a/blink.py
+++ b/blink.py
@@ -34,13 +34,16 @@ def output_handler(output_folder):
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
-    "-i",
-    "--input",
-    "input_file",
+    "-it",
+    "--inputType",
+    "input_type",
+    nargs=2,
     type=str,
-    required=True,
-    help="name of the input file (must be text file format; urls line by line).",
+    default="bulk",
+    show_default=True,
+    help="set the input type to single if only one url has to screenshotted and specify the url next, set to bulk if many urls exist and specfy the .txt folder next",
 )
+
 @click.option(
     "-o",
     "--output",
@@ -68,15 +71,24 @@ def output_handler(output_folder):
     show_default=True,
     help="webpage request timeout in seconds.",
 )
+
+
+
+
 @check_ssl
-def main(input_file, output_folder, window_size, time_out):
+def main(input_type, output_folder, window_size, time_out):
     output_location = output_handler(output_folder)
 
     options = webdriver.ChromeOptions()
     options.add_argument("headless")
     options.add_argument("window-size=%s" % window_size)
 
-    url_list = [line.rstrip() for line in open(input_handler(input_file), 'r')]
+    if(input_type[0] == "single"):
+        input_file = input_type[1]
+        url_list = [input_file]
+    else:
+        input_file = input_type[1]
+        url_list = [line.rstrip() for line in open(input_handler(input_file), 'r')]
 
     page_amount = len(url_list)
     page_counter = 0


### PR DESCRIPTION
I removed the input_file cmd line argument and instead, as you suggested, added -it argument where the user can specify single/bulk.
If single is given, then the url will be the next argument. Else if bulk is given as input type then the .txt file with the urls is given as the next argument.